### PR TITLE
[Chore] Update contract and improvements

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,11 +10,11 @@ chain:
   chain_id: 5611
   chain_name: "opBNB"
   rpc_url: "https://opbnb-testnet.nodereal.io/v1/9e210feafbec4ed9bd48f855c2bd979a"
-  start_block: 27320500
-  offset_block: 1
+  start_block: 0
+  offset_block: 3600 # opBNB block time: 1 sec. An offset of 3600 starts fetching blocks from 1 hours ago.
 contract:
-  addr: "0x39afd848cd4a83cddd06f340ae584c547e53873d"
-  tee_addr : "0x19baa72643aa11b28cb6251fd7596201778ead9a"
+  addr: "0xbd9a9ac0172f9eddebea4172fb7d9a3ca95cee52"
+  tee_addr : "0x7f57004E08ef1702b2b88b87ae01a561ae10F10e"
   topic: "0x99a038e9d345d0b12130b3b1fb003bf8f2d3a5c27ce2a800bbb1608efff6c591"
 wallet:
   mode: 0

--- a/internal/worker/error.go
+++ b/internal/worker/error.go
@@ -1,0 +1,23 @@
+package worker
+
+import (
+	"errors"
+	"strings"
+)
+
+// errorContainsMessage checks if the message of err1 is contained within any error in the chain of err2.
+func errorContainsMessage(err1, err2 error) bool {
+	targetMessage := err1.Error()
+	for {
+		if strings.Contains(err2.Error(), targetMessage) {
+			return true
+		}
+		// Unwrap the next error in the chain
+		unwrappedErr := errors.Unwrap(err2)
+		if unwrappedErr == nil {
+			break
+		}
+		err2 = unwrappedErr
+	}
+	return false
+}

--- a/internal/worker/verify.go
+++ b/internal/worker/verify.go
@@ -83,5 +83,4 @@ func verifyAttestation(c *Chain, bytesStr string) (bool, error) {
 	}
 
 	return true, nil
-
 }

--- a/pkg/dcap/quote.go
+++ b/pkg/dcap/quote.go
@@ -11,8 +11,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/carv-protocol/verifier/internal/conf"
 	"math/big"
+
+	"github.com/carv-protocol/verifier/internal/conf"
 )
 
 type Quote struct {
@@ -290,7 +291,6 @@ func GetQuoteV3Auth(quote []byte) (QuoteV3Auth, error) {
 		return QuoteV3Auth{}, errors.New("quote too short")
 	}
 	signatureLen := binary.LittleEndian.Uint32(quote[432:436])
-	fmt.Println(signatureLen)
 	var quoteAuth QuoteV3Auth
 	b := quote[436 : 436+signatureLen]
 	err := quoteAuth.FromBytes(b)


### PR DESCRIPTION
- Update contract and TEE addresses.
- Panic when having non-retriable errors.
- Set default start block to 0 and offset to 3600. It will by default start checking the attestation from 1 hour ago.
- Update batch posting interval to 10 seconds to prevent nonce collision when starting with multiple unverified attestations.